### PR TITLE
Prevent matching URLs in the middle of multi-line text

### DIFF
--- a/lib/yt/url.rb
+++ b/lib/yt/url.rb
@@ -41,21 +41,21 @@ module Yt
 
     # @return [Array<Regexp>] patterns matching URLs of YouTube playlists.
     PLAYLIST_PATTERNS = [
-       %r{^(?:https?://)?(?:www\.)?youtube\.com/playlist/?\?list=(?<id>[a-zA-Z0-9_-]+)},
+       %r{\A(?:https?://)?(?:www\.)?youtube\.com/playlist/?\?list=(?<id>[a-zA-Z0-9_-]+)},
     ]
 
     # @return [Array<Regexp>] patterns matching URLs of YouTube videos.
     VIDEO_PATTERNS = [
-      %r{^(?:https?://)?(?:www\.)?youtube\.com/watch\?v=(?<id>[a-zA-Z0-9_-]{11})},
-      %r{^(?:https?://)?(?:www\.)?youtu\.be/(?<id>[a-zA-Z0-9_-]{11})},
-      %r{^(?:https?://)?(?:www\.)?youtube\.com/embed/(?<id>[a-zA-Z0-9_-]{11})},
-      %r{^(?:https?://)?(?:www\.)?youtube\.com/v/(?<id>[a-zA-Z0-9_-]{11})},
+      %r{\A(?:https?://)?(?:www\.)?youtube\.com/watch\?v=(?<id>[a-zA-Z0-9_-]{11})},
+      %r{\A(?:https?://)?(?:www\.)?youtu\.be/(?<id>[a-zA-Z0-9_-]{11})},
+      %r{\A(?:https?://)?(?:www\.)?youtube\.com/embed/(?<id>[a-zA-Z0-9_-]{11})},
+      %r{\A(?:https?://)?(?:www\.)?youtube\.com/v/(?<id>[a-zA-Z0-9_-]{11})},
     ]
 
     # @return [Array<Regexp>] patterns matching URLs of YouTube channels.
     CHANNEL_PATTERNS = [
-      %r{^(?:https?://)?(?:www\.)?youtube\.com/channel/(?<id>UC[a-zA-Z0-9_-]{22})},
-      %r{^(?:https?://)?(?:www\.)?youtube\.com/(?<format>c/|user/)?(?<name>[a-zA-Z0-9_-]+)}
+      %r{\A(?:https?://)?(?:www\.)?youtube\.com/channel/(?<id>UC[a-zA-Z0-9_-]{22})},
+      %r{\A(?:https?://)?(?:www\.)?youtube\.com/(?<format>c/|user/)?(?<name>[a-zA-Z0-9_-]+)}
     ]
 
   private

--- a/spec/kind_spec.rb
+++ b/spec/kind_spec.rb
@@ -28,6 +28,11 @@ describe 'Yt::URL#kind' do
     it {expect(url.kind).to eq :unknown }
   end
 
+  context 'given a multi-line text containing a YouTube URL in the middle' do
+    let(:text) { "something-else\nyoutube.com/watch?v=gknzFj_0vvY" }
+    it {expect(url.kind).to eq :unknown }
+  end
+
   context 'given an unknown text' do
     let(:text) { 'not-really-anything---' }
     it {expect(url.kind).to eq :unknown }


### PR DESCRIPTION
In Ruby regexps, `^` and `$` match the beginning and end of a line in multi-line strings. This PR makes the URL patterns more strict, to avoid accidental garbage in front of the URL.